### PR TITLE
Report RSpec dry-run failures

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -7,10 +7,12 @@ GEM
   remote: https://rubygems.org/
   specs:
     ast (2.4.2)
+    base64 (0.3.0)
     diff-lcs (1.5.0)
     parallel (1.22.1)
     parser (3.1.2.0)
       ast (~> 2.4.1)
+    racc (1.8.1)
     rainbow (3.1.1)
     regexp_parser (2.3.1)
     rexml (3.2.5)
@@ -50,7 +52,9 @@ PLATFORMS
   x86_64-linux
 
 DEPENDENCIES
+  base64
   bundler
+  racc
   rspec
   rubocop
   rubocop-performance

--- a/bin/test_suite_splitter
+++ b/bin/test_suite_splitter
@@ -24,6 +24,11 @@ ARGV.each do |arg|
   args[hash_key] = value
 end
 
-rspec_helper = ::TestSuiteSplitter::RspecHelper.new(**args)
+begin
+  rspec_helper = ::TestSuiteSplitter::RspecHelper.new(**args)
 
-print rspec_helper.group_files.map { |group_file| group_file.fetch(:path) }.join(" ")
+  print rspec_helper.group_files.map { |group_file| group_file.fetch(:path) }.join(" ")
+rescue StandardError => error
+  puts error.message
+  exit 1
+end

--- a/bin/test_suite_splitter
+++ b/bin/test_suite_splitter
@@ -28,7 +28,7 @@ begin
   rspec_helper = ::TestSuiteSplitter::RspecHelper.new(**args)
 
   print rspec_helper.group_files.map { |group_file| group_file.fetch(:path) }.join(" ")
-rescue StandardError => error
-  puts error.message
+rescue StandardError => e
+  puts e.message
   exit 1
 end

--- a/lib/test_suite_splitter/rspec_helper.rb
+++ b/lib/test_suite_splitter/rspec_helper.rb
@@ -147,7 +147,7 @@ private
 
       result = ::JSON.parse(output_capture.string)
 
-      raise dry_run_error_message(result:, exit_code:) if result.fetch("examples").empty?
+      raise dry_run_error_message(result: result, exit_code: exit_code) if result.fetch("examples").empty?
 
       result
     end

--- a/lib/test_suite_splitter/rspec_helper.rb
+++ b/lib/test_suite_splitter/rspec_helper.rb
@@ -143,11 +143,11 @@ private
       require "stringio"
 
       output_capture = StringIO.new
-      RSpec::Core::Runner.run(rspec_options, $stderr, output_capture)
+      exit_code = RSpec::Core::Runner.run(rspec_options, $stderr, output_capture)
 
       result = ::JSON.parse(output_capture.string)
 
-      raise "No examples were found" if result.fetch("examples").empty?
+      raise dry_run_error_message(result:, exit_code:) if result.fetch("examples").empty?
 
       result
     end
@@ -209,6 +209,19 @@ private
     rspec_options << "spec"
 
     rspec_options
+  end
+
+  def dry_run_error_message(result:, exit_code:)
+    error_summary = []
+    errors_outside_of_examples_count = result.dig("summary", "errors_outside_of_examples_count")
+
+    error_summary << "exit_code=#{exit_code}"
+    error_summary << "errors_outside_of_examples_count=#{errors_outside_of_examples_count}" if errors_outside_of_examples_count.to_i > 0
+
+    first_message = result.fetch("messages", []).find { |message| message.strip != "" }
+    details = first_message&.strip || "No examples were found"
+
+    "RSpec dry-run failed (#{error_summary.join(', ')})\n\n#{details}"
   end
 
   def type_from_path(file_path)

--- a/lib/test_suite_splitter/rspec_helper.rb
+++ b/lib/test_suite_splitter/rspec_helper.rb
@@ -216,7 +216,7 @@ private
     errors_outside_of_examples_count = result.dig("summary", "errors_outside_of_examples_count")
 
     error_summary << "exit_code=#{exit_code}"
-    error_summary << "errors_outside_of_examples_count=#{errors_outside_of_examples_count}" if errors_outside_of_examples_count.to_i > 0
+    error_summary << "errors_outside_of_examples_count=#{errors_outside_of_examples_count}" if errors_outside_of_examples_count.to_i.positive?
 
     first_message = result.fetch("messages", []).find { |message| message.strip != "" }
     details = first_message&.strip || "No examples were found"

--- a/spec/bin/test_suite_splitter_spec.rb
+++ b/spec/bin/test_suite_splitter_spec.rb
@@ -14,7 +14,7 @@ describe "bin/test_suite_splitter" do
       expect(status.success?).to be false
       expect(stdout).to include("RSpec dry-run failed")
       expect(stdout).to include("An error occurred while loading ./spec/broken_spec.rb.")
-      expect(stdout).to include("Failure/Error: this is not valid ruby")
+      expect(stdout).to include("this is not valid ruby")
       expect(stderr).to eq("")
     end
   end

--- a/spec/bin/test_suite_splitter_spec.rb
+++ b/spec/bin/test_suite_splitter_spec.rb
@@ -1,0 +1,21 @@
+require "spec_helper"
+require "fileutils"
+require "open3"
+require "tmpdir"
+
+describe "bin/test_suite_splitter" do
+  it "prints the underlying rspec load error to stdout" do
+    Dir.mktmpdir do |dir|
+      FileUtils.mkdir_p("#{dir}/spec")
+      File.write("#{dir}/spec/broken_spec.rb", "this is not valid ruby\n")
+
+      stdout, stderr, status = Open3.capture3("ruby", File.expand_path("../../bin/test_suite_splitter", __dir__), "--groups=1", "--group-number=1", chdir: dir)
+
+      expect(status.success?).to be false
+      expect(stdout).to include("RSpec dry-run failed")
+      expect(stdout).to include("An error occurred while loading ./spec/broken_spec.rb.")
+      expect(stdout).to include("Failure/Error: this is not valid ruby")
+      expect(stderr).to eq("")
+    end
+  end
+end

--- a/spec/test_suite_splitter/rspec_helper_spec.rb
+++ b/spec/test_suite_splitter/rspec_helper_spec.rb
@@ -104,4 +104,24 @@ describe TestSuiteSplitter::RspecHelper do
       end
     end
   end
+
+  describe "#dry_result" do
+    it "includes the first rspec load error in the raised message" do
+      helper = TestSuiteSplitter::RspecHelper.new(groups: 1, group_number: 1)
+      result = {
+        "examples" => [],
+        "messages" => ["\nAn error occurred while loading ./spec/example_spec.rb.\nFailure/Error: boom\n"],
+        "summary" => {
+          "errors_outside_of_examples_count" => 1
+        }
+      }
+
+      allow(RSpec::Core::Runner).to receive(:run).and_return(1)
+      allow(JSON).to receive(:parse).and_return(result)
+
+      expect do
+        helper.__send__(:dry_result)
+      end.to raise_error(RuntimeError, /An error occurred while loading \.\/spec\/example_spec\.rb/)
+    end
+  end
 end

--- a/test_suite_splitter.gemspec
+++ b/test_suite_splitter.gemspec
@@ -22,7 +22,9 @@ Gem::Specification.new do |s|
   s.metadata = {"rubygems_mfa_required" => "true"}
   s.specification_version = 4 if s.respond_to? :specification_version
 
+  s.add_development_dependency("base64".freeze, [">= 0"])
   s.add_development_dependency("bundler".freeze, [">= 0"])
+  s.add_development_dependency("racc".freeze, [">= 0"])
   s.add_development_dependency("rspec".freeze, [">= 0"])
   s.add_development_dependency("rubocop".freeze, [">= 0"])
   s.add_development_dependency("rubocop-performance".freeze, [">= 0"])


### PR DESCRIPTION
## Summary
- print the underlying RSpec dry-run error message to stdout before exiting
- include the first JSON formatter load error when no examples are returned
- add regression coverage for both the helper error message and the CLI output

## Testing
- bundle exec rspec spec/bin/test_suite_splitter_spec.rb spec/test_suite_splitter/rspec_helper_spec.rb
- bundle exec ruby /home/dev/Development/test_suite_splitter/bin/test_suite_splitter --groups=2 --group-number=2 --only-types=features,requests,system 2>/dev/null
